### PR TITLE
Windows.fixes

### DIFF
--- a/sodium.go
+++ b/sodium.go
@@ -55,7 +55,7 @@ func (s *sodiumStream) Push(plaintext []byte, tag byte) ([]byte, error) {
 	defer C.free(pt)
 
 	cipher_len := len(plaintext) + C.crypto_secretstream_xchacha20poly1305_ABYTES
-	ct := C.malloc((C.ulong)(cipher_len))
+	ct := C.malloc((C.ulonglong)(cipher_len))
 	defer C.free(ct)
 
 	cipher_len_ull := C.ulonglong(cipher_len)
@@ -77,7 +77,7 @@ func (s *sodiumStream) Pull(ciphertext []byte) ([]byte, byte, error) {
 
 	mlen := C.ulong(len(ciphertext) - C.crypto_secretstream_xchacha20poly1305_ABYTES)
 	mlen_ull := C.ulonglong(mlen)
-	msg := C.malloc(mlen)
+	msg := C.malloc((C.ulonglong)(mlen))
 	var tag C.uchar
 
 	if C.crypto_secretstream_xchacha20poly1305_pull(&s.state,

--- a/sodium.go
+++ b/sodium.go
@@ -55,7 +55,7 @@ func (s *sodiumStream) Push(plaintext []byte, tag byte) ([]byte, error) {
 	defer C.free(pt)
 
 	cipher_len := len(plaintext) + C.crypto_secretstream_xchacha20poly1305_ABYTES
-	ct := C.malloc((C.ulonglong)(cipher_len))
+	ct := C.malloc((C.size_t)(cipher_len))
 	defer C.free(ct)
 
 	cipher_len_ull := C.ulonglong(cipher_len)
@@ -77,7 +77,7 @@ func (s *sodiumStream) Pull(ciphertext []byte) ([]byte, byte, error) {
 
 	mlen := C.ulong(len(ciphertext) - C.crypto_secretstream_xchacha20poly1305_ABYTES)
 	mlen_ull := C.ulonglong(mlen)
-	msg := C.malloc((C.ulonglong)(mlen))
+	msg := C.malloc((C.size_t)(mlen))
 	var tag C.uchar
 
 	if C.crypto_secretstream_xchacha20poly1305_pull(&s.state,


### PR DESCRIPTION
Attempting to fix the following error that happens during `go test --tags=compat_test ./...` on windows.

which was resulting in:

```
ok  	github.com/netfoundry/secretstream/kx	(cached)
# github.com/netfoundry/secretstream [github.com/netfoundry/secretstream.test]
FAIL    github.com/netfoundry/secretstream [build failed]
.\sodium.go:58:26: cannot use _Ctype_ulong(cipher_len) (type _Ctype_ulong) as ty
pe _Ctype_ulonglong in argument to _Cfunc__CMalloc
.\sodium.go:80:17: cannot use mlen (type _Ctype_ulong) as type _Ctype_ulonglong
in argument to _Cfunc__CMalloc
```